### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi-hyperref-narrow.bst
+++ b/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi-hyperref-narrow.bst
@@ -73,7 +73,7 @@ FUNCTION {add.link} % title
 	    {
 			  doi #1 #7 substring$ "http://" =
 				  { "\href{" doi * "}{" * t * "}" * }
-				  { "\href{http://dx.doi.org/" doi * "}{" * t * "}" * }
+				  { "\href{https://doi.org/" doi * "}{" * t * "}" * }
 				if$
 		  }
       if$ }
@@ -156,7 +156,7 @@ FUNCTION {add.doi}
           {
 					  #3 'nth.dash :=
 					  #1 'doi.string.pos :=
-						"https://dx.doi.org/" 'doi.urlstr :=
+						"https://doi.org/" 'doi.urlstr :=
 					}
           {}
         if$
@@ -172,7 +172,7 @@ FUNCTION {add.doi}
 					  {}
 					  {
 							#1 'doi.string.pos :=
-							"https://dx.doi.org/" 'doi.urlstr :=
+							"https://doi.org/" 'doi.urlstr :=
 						}
 					if$
 				}

--- a/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi-hyperref.bst
+++ b/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi-hyperref.bst
@@ -73,7 +73,7 @@ FUNCTION {add.link} % title
 	    {
 			  doi #1 #7 substring$ "http://" =
 				  { "\href{" doi * "}{" * t * "}" * }
-				  { "\href{http://dx.doi.org/" doi * "}{" * t * "}" * }
+				  { "\href{https://doi.org/" doi * "}{" * t * "}" * }
 				if$
 		  }
       if$ }
@@ -156,7 +156,7 @@ FUNCTION {add.doi}
           {
 					  #3 'nth.dash :=
 					  #1 'doi.string.pos :=
-						"https://dx.doi.org/" 'doi.urlstr :=
+						"https://doi.org/" 'doi.urlstr :=
 					}
           {}
         if$
@@ -172,7 +172,7 @@ FUNCTION {add.doi}
 					  {}
 					  {
 							#1 'doi.string.pos :=
-							"https://dx.doi.org/" 'doi.urlstr :=
+							"https://doi.org/" 'doi.urlstr :=
 						}
 					if$
 				}

--- a/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi-narrow.bst
+++ b/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi-narrow.bst
@@ -73,7 +73,7 @@ FUNCTION {add.link} % title
 	    {
 			  doi #1 #7 substring$ "http://" =
 				  { "\href{" doi * "}{" * t * "}" * }
-				  { "\href{http://dx.doi.org/" doi * "}{" * t * "}" * }
+				  { "\href{https://doi.org/" doi * "}{" * t * "}" * }
 				if$
 		  }
       if$ }
@@ -156,7 +156,7 @@ FUNCTION {add.doi}
           {
 					  #3 'nth.dash :=
 					  #1 'doi.string.pos :=
-						"https://dx.doi.org/" 'doi.urlstr :=
+						"https://doi.org/" 'doi.urlstr :=
 					}
           {}
         if$
@@ -172,7 +172,7 @@ FUNCTION {add.doi}
 					  {}
 					  {
 							#1 'doi.string.pos :=
-							"https://dx.doi.org/" 'doi.urlstr :=
+							"https://doi.org/" 'doi.urlstr :=
 						}
 					if$
 				}

--- a/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi.bst
+++ b/cs458_sedwick_kabir/Planet_LaTeX/abbrv-doi.bst
@@ -73,7 +73,7 @@ FUNCTION {add.link} % title
 	    {
 			  doi #1 #7 substring$ "http://" =
 				  { "\href{" doi * "}{" * t * "}" * }
-				  { "\href{http://dx.doi.org/" doi * "}{" * t * "}" * }
+				  { "\href{https://doi.org/" doi * "}{" * t * "}" * }
 				if$
 		  }
       if$ }
@@ -156,7 +156,7 @@ FUNCTION {add.doi}
           {
 					  #3 'nth.dash :=
 					  #1 'doi.string.pos :=
-						"https://dx.doi.org/" 'doi.urlstr :=
+						"https://doi.org/" 'doi.urlstr :=
 					}
           {}
         if$
@@ -172,7 +172,7 @@ FUNCTION {add.doi}
 					  {}
 					  {
 							#1 'doi.string.pos :=
-							"https://dx.doi.org/" 'doi.urlstr :=
+							"https://doi.org/" 'doi.urlstr :=
 						}
 					if$
 				}

--- a/cs458_sedwick_kabir/Planet_LaTeX/template.bib
+++ b/cs458_sedwick_kabir/Planet_LaTeX/template.bib
@@ -16,7 +16,7 @@
 	OPTnumber = {},
 	OPTmonth = {},
 	OPTpages = {},
-	doi = {http://dx.doi.org/10.1109/TVCG.2016.2615308},
+	doi = {https://doi.org/10.1109/TVCG.2016.2615308},
   OPTgooglescholarid = {},
 	note = {To appear},
 }
@@ -89,7 +89,7 @@
   year = 2004,
   publisher = {Morgan Kaufmann Publishers Inc.},
   address = {San Francisco},
-	doi = {https://dx.doi.org/10.1016/B978-155860819-1/50001-7}
+	doi = {https://doi.org/10.1016/B978-155860819-1/50001-7}
 }
 
 @ARTICLE{Wyvill:1986:DSS,
@@ -101,5 +101,5 @@
   pages = {227--234},
   number = {4},
   month = aug,
-  doi = {http://dx.doi.org/10.1007/BF01900346}
+  doi = {https://doi.org/10.1007/BF01900346}
 }


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!